### PR TITLE
Fix for password confirmation bug

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -5,10 +5,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   protected
 
   def configure_sign_up_params
-    devise_parameter_sanitizer.for(:sign_up) { |u| u.permit(:first_name, :last_name, :email, :phone, :password) }
+    devise_parameter_sanitizer.for(:sign_up) { |u| u.permit(:first_name, :last_name, :email, :phone, :password, :password_confirmation) }
   end
 
   def configure_account_update_params
-    devise_parameter_sanitizer.for(:account_update) { |u| u.permit(:first_name, :last_name, :email, :phone, :password, :current_password) }
+    devise_parameter_sanitizer.for(:account_update) { |u| u.permit(:first_name, :last_name, :email, :phone, :password, :current_password, :password_confirmation) }
   end
 end

--- a/spec/features/user_edits_spec.rb
+++ b/spec/features/user_edits_spec.rb
@@ -55,4 +55,19 @@ RSpec.feature "UserEdits", type: :feature do
 
     expect(page).to have_text("Signed in successfully.")
   end
+
+  scenario "User does not enter a password confirmation" do
+    login_as user
+    visit "/"
+
+    click_link 'Edit Account'
+
+    fill_in 'Password', with: 'newpassword'
+    fill_in 'Current password', with: 'test1234'
+
+    click_button 'Update'
+
+    expect(page).to_not have_text("Your account has been updated successfully.")
+    expect(page).to have_text("Password confirmation doesn't match")
+  end
 end


### PR DESCRIPTION
This is fix for the missing password confirmation field bug. 

Previously, password confirmation param was not allowed in the account update or create requests, so it was being ignored. This meant that the password confirmation was not required to change the password. This simply adds that field to strong_params and adds a spec to cover that case.
